### PR TITLE
Read SONG note decay timing from JSON

### DIFF
--- a/src/sms/SampleCache.cc
+++ b/src/sms/SampleCache.cc
@@ -1,6 +1,6 @@
 #include "SampleCache.hh"
 
-#include <phosg/Strings.hh>
+#include <format>
 
 using namespace std;
 
@@ -27,7 +27,7 @@ vector<float> resample(
 
   int error = src_simple(&data, resample_method, num_channels);
   if (error) {
-    throw runtime_error(phosg::string_printf("src_simple failed (ratio=%g): %s", src_ratio, src_strerror(error)));
+    throw runtime_error(format("src_simple failed (ratio={}): {}", src_ratio, src_strerror(error)));
   }
 
   output_samples.resize(data.output_frames_gen * num_channels);

--- a/src/sms/instrument.cc
+++ b/src/sms/instrument.cc
@@ -6,7 +6,7 @@
 
 #include <phosg/Encoding.hh>
 #include <phosg/Filesystem.hh>
-#include <phosg/Strings.hh>
+#include <format>
 #include <vector>
 
 #include "afc.hh"
@@ -330,8 +330,9 @@ Instrument ibnk_inst_decode(const void* vdata, size_t offset, size_t inst_id) {
     count = 0x64;
 
   } else {
-    throw invalid_argument(phosg::string_printf("unknown instrument format at %08zX: %.4s (%08X)",
-        offset, inst_data, *reinterpret_cast<const uint32_t*>(inst_data)));
+    throw invalid_argument(format("unknown instrument format at {:08X}: {:.4} ({:08X})",
+        offset, string_view(reinterpret_cast<const char*>(inst_data), 4),
+            *reinterpret_cast<const uint32_t*>(inst_data)));
   }
 
   for (uint32_t x = 0; x < count; x++) {
@@ -437,11 +438,11 @@ InstrumentBank ibnk_decode(const void* vdata) {
       offset += list_header->size + sizeof(ibnk_list_header);
 
     } else if (!memcmp(&chunk_header->magic, "BANK", 4)) {
-      throw runtime_error(phosg::string_printf("IBNK contains BANK at %08zX but it is not first",
+      throw runtime_error(format("IBNK contains BANK at {:08X} but it is not first",
           offset));
 
     } else {
-      throw runtime_error(phosg::string_printf("unknown IBNK chunk type at %08zX: %.4s",
+      throw runtime_error(format("unknown IBNK chunk type at {:08X}: {:.4}",
           offset, reinterpret_cast<const char*>(&chunk_header->magic)));
     }
   }


### PR DESCRIPTION
fuzziqersoftware/resource_dasm#85 adds support for writing the note decay data embedded in classic Mac SONG resources to JSON. This PR updates smssynth to read this data. There's also a commit in here that gets smssynth building with the latest phosg changes.

This was used extensively in the music of SimCity 2000, and the before/after is striking:

https://github.com/user-attachments/assets/445a3aca-b97c-41e0-b391-5c07cafd5dae

https://github.com/user-attachments/assets/03f8535e-794e-489c-a4a2-e5330a7e06ec

Let me know if there's anything about the implementation you'd like me to change, C++ isn't my forte and I just tried to minimize the blast radius of these changes.